### PR TITLE
Initialize TypeCrypt skeleton

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,3 @@
+# TypeCrypt Project Overview
+
+This folder will contain design documents and specifications shared across the three implementations.

--- a/haskell/README.md
+++ b/haskell/README.md
@@ -1,0 +1,8 @@
+# TypeCrypt Haskell (Theory Branch)
+
+This directory contains the formal specification and type logic implementation.
+
+- `src/Types.hs` defines the core `Type` and `Value` algebra.
+- Future modules will implement symbolic matching and encryption logic.
+
+Run `cabal test` or `stack test` once tests are added.

--- a/haskell/src/Types.hs
+++ b/haskell/src/Types.hs
@@ -1,0 +1,13 @@
+module Types where
+
+-- | Placeholder for type algebra definitions.
+data Type
+  = TInt
+  | TString
+  deriving (Show, Eq)
+
+-- | Placeholder for value representations.
+data Value
+  = VInt Int
+  | VString String
+  deriving (Show, Eq)

--- a/haskell/typecrypt.cabal
+++ b/haskell/typecrypt.cabal
@@ -1,0 +1,11 @@
+cabal-version: 2.4
+name: typecrypt
+version: 0.1.0.0
+build-type: Simple
+
+default-language: Haskell2010
+
+library
+  exposed-modules: Types
+  hs-source-dirs: src
+  build-depends: base >=4.7 && <5

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "typecrypt"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,5 @@
+# TypeCrypt Rust (Production Branch)
+
+This crate aims to provide a secure and high-performance implementation of TypeCrypt.
+
+Code is organized under `src/` and will expose a library crate for embedding into applications.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,15 @@
+//! TypeCrypt Rust (Production Branch)
+//!
+//! This crate will implement the hardened TypeCrypt engine.
+
+#[derive(Debug)]
+pub enum Type {
+    Int,
+    Str,
+}
+
+#[derive(Debug)]
+pub enum Value {
+    Int(i32),
+    Str(String),
+}

--- a/zig/README.md
+++ b/zig/README.md
@@ -1,0 +1,3 @@
+# TypeCrypt Zig (Experimental Branch)
+
+This directory experiments with compile-time features of Zig to implement TypeCrypt.


### PR DESCRIPTION
## Summary
- create directories for Haskell, Rust, Zig, and docs
- stub `Types` module in Haskell
- add minimal Rust crate
- add docs overview

## Testing
- `cargo check --lib`

------
https://chatgpt.com/codex/tasks/task_e_6862915c398483289a3c2335af9f7656