### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  haskell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: haskell/actions/setup@v2
+        with:
+          ghc-version: '9.2'
+          cabal-version: '3.6'
+      - run: |
+          cd haskell
+          cabal update
+          cabal build
+
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - run: cargo test --verbose --manifest-path rust/Cargo.toml
+
+  zig:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: 0.11.0
+      - run: zig version

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts
+rust/target/
+**/target/
+**/.stack-work/
+**/dist-newstyle/
+*.hi
+*.o
+*.beam
+*.swp


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow that builds Haskell and Rust code and checks Zig installation
- add `.gitignore`

## Testing
- `cargo test` *(passes)*
- `cabal build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686291db82e88328905b5026fefb0714