### PR TITLE
Add GitHub Pages CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,30 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Build docs
+        run: |
+          mkdir _site
+          cp -r docs/* _site/
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./_site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ This repo contains three coordinated implementations:
 In TypeCrypt, types are not just annotations — they are *structural constraints* that serve as decryption keys. A ciphertext encrypted under a type `T` can only be decrypted by a value of type `T`.
 
 This flips conventional cryptography on its head: instead of using values to unlock data, you must *satisfy a type* to access it.
+
+---
+
+## 🚀 Continuous Deployment
+
+A GitHub Actions workflow publishes the contents of `docs/` to GitHub Pages
+whenever the `main` branch is updated.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for deploying `docs` to GitHub Pages
- document the new continuous deployment setup in the README

## Testing
- `cargo test --quiet`
- `cabal test --test-show-details=direct` *(fails: `cabal` not found)*
- `zig build test` *(fails: `zig` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862958e3938832894c038da8cc9b8af