### PR TITLE
Add Zig prototype scaffolding

### DIFF
--- a/zig/README.md
+++ b/zig/README.md
@@ -1,3 +1,7 @@
 # TypeCrypt Zig (Experimental Branch)
 
 This directory experiments with compile-time features of Zig to implement TypeCrypt.
+
+## Build
+
+Run `zig build` from this directory to compile the experimental executable. It demonstrates a basic type enumeration and a compile-time `typeHash` utility.

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const mode = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "typecrypt_zig",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = mode,
+    });
+
+    b.installArtifact(exe);
+}

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+
+/// Experimental compile-time type enumeration.
+/// Mirrors the "Type" variants from other implementations.
+pub const Type = enum {
+    Int,
+    Str,
+};
+
+/// A value tagged with its Type.
+pub const Value = union(Type) {
+    Int: i32,
+    Str: []const u8,
+};
+
+/// Compute a compile-time hash of a Zig type.
+/// Currently uses a simple FNV-1a hash of the type name.
+pub fn typeHash(comptime T: type) u64 {
+    var hash: u64 = 0xcbf29ce484222325;
+    const name = @typeName(T);
+    for (name) |c| {
+        hash = (hash ^ @as(u64, c)) * 0x100000001b3;
+    }
+    return hash;
+}
+
+pub fn main() void {
+    const int_hash = typeHash(i32);
+    const str_hash = typeHash([]const u8);
+    std.debug.print("int hash: {x}\n", .{int_hash});
+    std.debug.print("str hash: {x}\n", .{str_hash});
+}


### PR DESCRIPTION
## Summary
- add build.zig for an experimental Zig executable
- implement a simple compile-time `Type` and `Value` with `typeHash`
- document how to build the experimental project

## Testing
- `zig build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686295b960208328bf84c5bfb48c8b04