### PR TITLE
Fix tests in Rust module

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -80,7 +80,9 @@ mod tests {
         let wrong = Value::Str("oops".into());
         let ct = encrypt(&ty, b"secret");
         assert!(decrypt_with_value(&ty, &wrong, &ct).is_none());
+    }
 
+    #[test]
     fn matches_int() {
         assert!(matches(&Value::Int(42), &Type::Int));
         assert!(!matches(&Value::Int(42), &Type::Str));


### PR DESCRIPTION
## Summary
- fix missing brace in `decrypt_rejects_wrong_value`
- mark `matches_int` as a test

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6862987ae7f08328bf18263a4e7f0c17