### PR TITLE
Fix CD workflow for new artifact action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,18 +13,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
       - name: Build docs
         run: |
           mkdir _site
           cp -r docs/* _site/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./_site
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
## Summary
- update GitHub pages workflow actions to supported versions

## Testing
- `cargo test --manifest-path rust/Cargo.toml` *(fails: duplicate key in Cargo.lock)*
- `cabal build all` *(fails: command not found)*
- `zig version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686298d09d4c8328a20109c78caeca7c