### PR TITLE
Extend Haskell encrypt/decrypt with AEAD

### DIFF
--- a/haskell/src/Types.hs
+++ b/haskell/src/Types.hs
@@ -2,6 +2,12 @@
 {-# LANGUAGE StandaloneDeriving #-}
 module Types where
 
+import qualified Crypto.Cipher.ChaChaPoly1305 as C
+import           Crypto.Error (CryptoFailable(..), throwCryptoError)
+import           Crypto.MAC.Poly1305 (authTag)
+import           Data.ByteArray (convert)
+import qualified Data.ByteString as B
+
 import Data.ByteString (ByteString)
 
 -- | Type algebra using GADTs.
@@ -43,13 +49,38 @@ sameType (TPair a1 b1) (TPair a2 b2) = sameType a1 a2 && sameType b1 b2
 sameType (TList t1) (TList t2) = sameType t1 t2
 sameType _ _ = False
 
--- | Placeholder encryption using types as keys.
--- For now this simply echoes the input.
-encrypt :: Type a -> ByteString -> ByteString
-encrypt _ bs = bs
+-- | Internal: derive a symmetric key from a 'Type'.
+keyFromType :: Type a -> B.ByteString
+keyFromType TInt      = B.replicate 32 0
+keyFromType TString   = B.replicate 32 1
+keyFromType TBool     = B.replicate 32 2
+keyFromType (TPair _ _) = B.replicate 32 3
+keyFromType (TList _) = B.replicate 32 4
 
--- | Decrypt only if the provided value matches the type key.
+-- | Encrypt the input using ChaCha20-Poly1305 with a key derived from the type.
+encrypt :: Type a -> ByteString -> ByteString
+encrypt ty plaintext =
+  let key   = keyFromType ty
+      nonce = either (error "invalid nonce") id $ C.nonce12 (B.replicate 12 0)
+      st1   = throwCryptoError $ C.initialize key nonce
+      st2   = C.finalizeAAD st1
+      (out, st3) = C.encrypt plaintext st2
+      tag   = C.finalize st3
+  in out `B.append` convert tag
+
+-- | Decrypt if the value matches the expected type and authentication tag checks.
 decrypt :: Type a -> Value -> ByteString -> Maybe ByteString
-decrypt t v bs
-  | matches v t = Just bs
-  | otherwise   = Nothing
+decrypt ty val input
+  | not (matches val ty) = Nothing
+  | B.length input < 16  = Nothing
+  | otherwise =
+      let (ct, tagBytes) = B.splitAt (B.length input - 16) input
+          key   = keyFromType ty
+          nonce = either (error "invalid nonce") id $ C.nonce12 (B.replicate 12 0)
+          st1   = throwCryptoError $ C.initialize key nonce
+          st2   = C.finalizeAAD st1
+          (pt, st3) = C.decrypt ct st2
+          tag   = C.finalize st3
+       in case authTag tagBytes of
+            CryptoFailed _ -> Nothing
+            CryptoPassed t -> if t == tag then Just pt else Nothing

--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -9,3 +9,11 @@ main = hspec $ do
       matches (V TInt n) TInt
     it "returns False for mismatched Type" $ property $ \n ->
       not (matches (V TInt n) TString)
+
+  describe "encrypt/decrypt" $ do
+    it "roundtrips for Int" $ property $ \(n :: Int) bs ->
+      let ct = encrypt TInt bs
+       in decrypt TInt (V TInt n) ct == Just bs
+    it "roundtrips for String" $ property $ \(s :: String) bs ->
+      let ct = encrypt TString bs
+       in decrypt TString (V TString s) ct == Just bs

--- a/haskell/typecrypt.cabal
+++ b/haskell/typecrypt.cabal
@@ -8,7 +8,8 @@ library
   hs-source-dirs: src
   build-depends:
       base >=4.7 && <5,
-      bytestring >=0.10
+      bytestring >=0.10,
+      cryptonite >=0.27
   default-language: Haskell2010
 
 test-suite spec
@@ -19,6 +20,7 @@ test-suite spec
       base >=4.7 && <5,
       typecrypt,
       bytestring,
+      cryptonite >=0.27,
       QuickCheck,
       hspec >=2.7
   default-language: Haskell2010


### PR DESCRIPTION
## Summary
- implement real ChaCha20‑Poly1305 encryption in `Types.hs`
- derive a symmetric key from the type
- expose new QuickCheck properties for round‑tripping
- depend on `cryptonite`

## Testing
- `cabal test --test-show-details=streaming` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686298977800832888105147ee62bdff