### PR TITLE
Add unified test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Each language implementation lives in its own subdirectory. To compile and verif
   zig build
   ```
 
+For convenience, you can run all of the above with:
+
+```bash
+./run_all_tests.sh
+```
+
 ## License
 
 TypeCrypt is released under the [MIT License](LICENSE).

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Run all TypeCrypt test suites
+set -e
+
+( cd haskell && cabal test )
+( cd rust && cargo test )
+( cd zig && zig build )


### PR DESCRIPTION
## Summary
- add `run_all_tests.sh` convenience script
- document the script in README

## Testing
- `cargo test` *(fails: unclosed delimiter)*
- `zig build` *(fails: command not found)*
- `cabal test` *(fails: command not found)*
- `./run_all_tests.sh` *(fails: cabal not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629c3e131c83288c1005ca4955bfbd