### PR TITLE
Fix Rust tests build error

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -137,6 +137,7 @@ mod tests {
         let v = Value::List(vec![Value::Int(1), Value::Int(2)]);
         let t = Type::List(Box::new(Type::Int));
         assert!(matches(&v, &t));
+    }
 
     #[test]
     fn multiple_encryptions_use_different_nonces() {


### PR DESCRIPTION
## Summary
- close unclosed brace in Rust unit tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68629c2bb5fc8328adba79f11bbe57da