### PR TITLE
Add Racket assembly prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 **TypeCrypt** is an encryption system where *types themselves are the key*. Decryption is only possible if a submitted value *resolves to the expected type*.
 
-This repo contains three coordinated implementations:
+This repo contains four coordinated implementations:
 
 - **Haskell** – the *Theory Branch*: formal specification, correctness, and type-driven logic.
 - **Rust** – the *Production Branch*: hardened system for real-world usage, throughput-optimized.
 - **Zig** – the *Experimental Branch*: compile-time metaprogramming, radical flexibility, and rapid prototyping.
+- **Racket** – the *Assembly Branch*: emits x86\_64 assembly for low-level exploration.
 
 ---
 
@@ -41,6 +42,11 @@ Each language implementation lives in its own subdirectory. To compile and verif
   ```bash
   cd zig
   zig build
+  ```
+- **Racket**
+  ```bash
+  cd racket
+  racket main.rkt
   ```
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # TypeCrypt: Roadmap
 
-This document outlines the plan for developing TypeCrypt across the three branches: Theory (Haskell), Production (Rust), and Experimental (Zig).
+This document outlines the plan for developing TypeCrypt across four branches: Theory (Haskell), Production (Rust), Experimental (Zig), and Assembly (Racket).
 
 ---
 
@@ -50,6 +50,17 @@ This document outlines the plan for developing TypeCrypt across the three branch
 
 ---
 
+### 🟣 Racket (Assembly Branch)
+
+> _Purpose_: Explore direct assembly generation and low-level optimizations.
+
+**Goals:**
+- [ ] Emit minimal x86_64 assembly for sample operations
+- [ ] Provide a test harness for verifying generated code
+- [ ] Integrate with other branches via shared IR
+
+---
+
 ## 🧮 Long-Term Goals
 
 - [ ] Transpile Haskell IR to:
@@ -69,6 +80,7 @@ This document outlines the plan for developing TypeCrypt across the three branch
 - Haskell drives spec and logic
 - Rust implements hardened infrastructure
 - Zig tests radical or low-level enhancements
+- Racket explores direct assembly generation
 
 Each branch feeds into the others iteratively to improve correctness, performance, and flexibility.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,6 +14,9 @@ This document summarizes the basic coding style used in this repository and how 
 ### Zig
 - Format all Zig files with `zig fmt`.
 
+### Racket
+- Use `raco fmt` for formatting. Run `raco fmt <file>` before committing.
+
 ## Running Tests
 
 ### Haskell
@@ -40,6 +43,14 @@ cd zig
 zig build
 ```
 
+### Racket
+Generate the assembly output by running:
+
+```bash
+cd racket
+racket main.rkt
+```
+
 ## Multi-Language Workflow
 
-This project coordinates changes across the Haskell, Rust and Zig implementations. See `AGENTS.md` in the repository root for details on how updates should flow between these directories.
+This project coordinates changes across the Haskell, Rust, Zig and Racket implementations. See `AGENTS.md` in the repository root for details on how updates should flow between these directories.

--- a/haskell/src/Types.hs
+++ b/haskell/src/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
+
 module Types where
 
 import Data.ByteString (ByteString)
@@ -7,11 +8,11 @@ import Data.ByteString (ByteString)
 -- | Type algebra using GADTs.
 -- Each constructor carries the concrete type it represents.
 data Type a where
-  TInt   :: Type Int
+  TInt :: Type Int
   TString :: Type String
-  TBool  :: Type Bool
-  TPair  :: Type a -> Type b -> Type (a, b)
-  TList  :: Type a -> Type [a]
+  TBool :: Type Bool
+  TPair :: Type a -> Type b -> Type (a, b)
+  TList :: Type a -> Type [a]
 
 -- Show instance for existential 'Type'
 deriving instance Show (Type a)
@@ -23,9 +24,9 @@ data Value where
 
 -- Show instance for 'Value'
 instance Show Value where
-  show (V TInt n)      = "VInt " ++ show n
-  show (V TString s)   = "VString " ++ show s
-  show (V TBool b)     = "VBool " ++ show b
+  show (V TInt n) = "VInt " ++ show n
+  show (V TString s) = "VString " ++ show s
+  show (V TBool b) = "VBool " ++ show b
   show (V (TPair _ _) _) = "VPair"
   show (V (TList _) _) = "VList"
 
@@ -52,4 +53,4 @@ encrypt _ bs = bs
 decrypt :: Type a -> Value -> ByteString -> Maybe ByteString
 decrypt t v bs
   | matches v t = Just bs
-  | otherwise   = Nothing
+  | otherwise = Nothing

--- a/racket/README.md
+++ b/racket/README.md
@@ -1,0 +1,5 @@
+# TypeCrypt Racket (Assembly Branch)
+
+This directory contains a small Racket prototype that demonstrates emitting x86_64 assembly.
+
+Running `racket main.rkt` will generate an `output.s` file with assembly for a simple addition function.

--- a/racket/main.rkt
+++ b/racket/main.rkt
@@ -1,0 +1,28 @@
+#lang racket
+
+;; Simple Racket script to emit x86_64 assembly for an integer addition
+
+(struct Type (name) #:transparent)
+(struct Value (type val) #:transparent)
+
+(define TInt (Type 'int))
+
+;; Check if a Value matches a Type
+(define (matches v t)
+  (eq? (Type-name (Value-type v)) (Type-name t)))
+
+;; Emit assembly that adds two integers and returns the result in rax
+(define (emit-add v1 v2)
+  (unless (and (matches v1 TInt) (matches v2 TInt))
+    (error 'emit-add "values must be integers"))
+  (with-output-to-file "output.s" #:exists 'replace
+    (lambda ()
+      (displayln "    .text")
+      (displayln "    .global add")
+      (displayln "add:")
+      (displayln "    mov rax, rdi")
+      (displayln "    add rax, rsi")
+      (displayln "    ret"))))
+
+(module+ main
+  (emit-add (Value TInt 1) (Value TInt 2)))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,7 +22,6 @@ pub fn matches(value: &Value, ty: &Type) -> bool {
     }
 }
 
-
 use ring::aead;
 use ring::rand::{SecureRandom, SystemRandom};
 
@@ -31,8 +30,7 @@ fn key_from_type(ty: &Type) -> aead::LessSafeKey {
         Type::Int => [0u8; 32],
         Type::Str => [1u8; 32],
     };
-    let unbound = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &bytes)
-        .expect("invalid key");
+    let unbound = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &bytes).expect("invalid key");
     aead::LessSafeKey::new(unbound)
 }
 
@@ -52,11 +50,7 @@ pub fn encrypt(ty: &Type, plaintext: &[u8]) -> Vec<u8> {
 }
 
 /// Decrypt the ciphertext if the value matches the expected type.
-pub fn decrypt_with_value(
-    ty: &Type,
-    value: &Value,
-    ciphertext: &[u8],
-) -> Option<Vec<u8>> {
+pub fn decrypt_with_value(ty: &Type, value: &Value, ciphertext: &[u8]) -> Option<Vec<u8>> {
     if !matches(value, ty) {
         return None;
     }
@@ -68,7 +62,9 @@ pub fn decrypt_with_value(
     nonce_bytes.copy_from_slice(&ciphertext[..12]);
     let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
     let mut in_out = ciphertext[12..].to_vec();
-    let result = key.open_in_place(nonce, aead::Aad::empty(), &mut in_out).ok()?;
+    let result = key
+        .open_in_place(nonce, aead::Aad::empty(), &mut in_out)
+        .ok()?;
     Some(result.to_vec())
 }
 


### PR DESCRIPTION
## Summary
- add `racket` folder with simple assembly emitter
- document Racket branch in README, roadmap, and development docs
- format existing sources

## Testing
- `cabal test`
- `cargo test`
- `zig build` *(fails: command not found)*
- `racket racket/main.rkt`

------
https://chatgpt.com/codex/tasks/task_e_68629ba5e32083288cd503f12c0154d6