### PR TITLE
Extend Haskell tests for TPair and TList

### DIFF
--- a/haskell/src/Types.hs
+++ b/haskell/src/Types.hs
@@ -1,23 +1,23 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
+
 module Types where
 
 import qualified Crypto.Cipher.ChaChaPoly1305 as C
-import           Crypto.Error (CryptoFailable(..), throwCryptoError)
-import           Crypto.MAC.Poly1305 (authTag)
-import           Data.ByteArray (convert)
-import qualified Data.ByteString as B
-
+import Crypto.Error (CryptoFailable (..), throwCryptoError)
+import Crypto.MAC.Poly1305 (authTag)
+import Data.ByteArray (convert)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as B
 
 -- | Type algebra using GADTs.
 -- Each constructor carries the concrete type it represents.
 data Type a where
-  TInt   :: Type Int
+  TInt :: Type Int
   TString :: Type String
-  TBool  :: Type Bool
-  TPair  :: Type a -> Type b -> Type (a, b)
-  TList  :: Type a -> Type [a]
+  TBool :: Type Bool
+  TPair :: Type a -> Type b -> Type (a, b)
+  TList :: Type a -> Type [a]
 
 -- Show instance for existential 'Type'
 deriving instance Show (Type a)
@@ -29,9 +29,9 @@ data Value where
 
 -- Show instance for 'Value'
 instance Show Value where
-  show (V TInt n)      = "VInt " ++ show n
-  show (V TString s)   = "VString " ++ show s
-  show (V TBool b)     = "VBool " ++ show b
+  show (V TInt n) = "VInt " ++ show n
+  show (V TString s) = "VString " ++ show s
+  show (V TBool b) = "VBool " ++ show b
   show (V (TPair _ _) _) = "VPair"
   show (V (TList _) _) = "VList"
 
@@ -51,36 +51,40 @@ sameType _ _ = False
 
 -- | Internal: derive a symmetric key from a 'Type'.
 keyFromType :: Type a -> B.ByteString
-keyFromType TInt      = B.replicate 32 0
-keyFromType TString   = B.replicate 32 1
-keyFromType TBool     = B.replicate 32 2
+keyFromType TInt = B.replicate 32 0
+keyFromType TString = B.replicate 32 1
+keyFromType TBool = B.replicate 32 2
 keyFromType (TPair _ _) = B.replicate 32 3
 keyFromType (TList _) = B.replicate 32 4
 
 -- | Encrypt the input using ChaCha20-Poly1305 with a key derived from the type.
 encrypt :: Type a -> ByteString -> ByteString
 encrypt ty plaintext =
-  let key   = keyFromType ty
-      nonce = either (error "invalid nonce") id $ C.nonce12 (B.replicate 12 0)
-      st1   = throwCryptoError $ C.initialize key nonce
-      st2   = C.finalizeAAD st1
+  let key = keyFromType ty
+      nonce = case C.nonce12 (B.replicate 12 0) of
+        CryptoFailed _ -> error "invalid nonce"
+        CryptoPassed n -> n
+      st1 = throwCryptoError $ C.initialize key nonce
+      st2 = C.finalizeAAD st1
       (out, st3) = C.encrypt plaintext st2
-      tag   = C.finalize st3
-  in out `B.append` convert tag
+      tag = C.finalize st3
+   in out `B.append` convert tag
 
 -- | Decrypt if the value matches the expected type and authentication tag checks.
 decrypt :: Type a -> Value -> ByteString -> Maybe ByteString
 decrypt ty val input
   | not (matches val ty) = Nothing
-  | B.length input < 16  = Nothing
+  | B.length input < 16 = Nothing
   | otherwise =
       let (ct, tagBytes) = B.splitAt (B.length input - 16) input
-          key   = keyFromType ty
-          nonce = either (error "invalid nonce") id $ C.nonce12 (B.replicate 12 0)
-          st1   = throwCryptoError $ C.initialize key nonce
-          st2   = C.finalizeAAD st1
+          key = keyFromType ty
+          nonce = case C.nonce12 (B.replicate 12 0) of
+            CryptoFailed _ -> error "invalid nonce"
+            CryptoPassed n -> n
+          st1 = throwCryptoError $ C.initialize key nonce
+          st2 = C.finalizeAAD st1
           (pt, st3) = C.decrypt ct st2
-          tag   = C.finalize st3
+          tag = C.finalize st3
        in case authTag tagBytes of
             CryptoFailed _ -> Nothing
             CryptoPassed t -> if t == tag then Just pt else Nothing

--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as B
 import Test.Hspec
 import Test.QuickCheck
 import Types
+
+instance Arbitrary ByteString where
+  arbitrary = B.pack <$> arbitrary
 
 main :: IO ()
 main = hspec $ do
@@ -9,6 +16,10 @@ main = hspec $ do
       matches (V TInt n) TInt
     it "returns False for mismatched Type" $ property $ \n ->
       not (matches (V TInt n) TString)
+    it "matches nested Pair/List" $ property $ \n xs ->
+      matches
+        (V (TPair TInt (TList TString)) (n, xs))
+        (TPair TInt (TList TString))
 
   describe "encrypt/decrypt" $ do
     it "roundtrips for Int" $ property $ \(n :: Int) bs ->
@@ -17,9 +28,25 @@ main = hspec $ do
     it "roundtrips for String" $ property $ \(s :: String) bs ->
       let ct = encrypt TString bs
        in decrypt TString (V TString s) ct == Just bs
+    it "roundtrips for (Int, String)" $ property $ \(a :: Int) (b :: String) bs ->
+      let ty = TPair TInt TString
+          val = V ty (a, b)
+          ct = encrypt ty bs
+       in decrypt ty val ct == Just bs
+    it "roundtrips for [Int]" $ property $ \(xs :: [Int]) bs ->
+      let ty = TList TInt
+          val = V ty xs
+          ct = encrypt ty bs
+       in decrypt ty val ct == Just bs
+    it "roundtrips for nested (Int, [String])" $
+      property $ \(n :: Int) (xs :: [String]) bs ->
+        let ty = TPair TInt (TList TString)
+            val = V ty (n, xs)
+            ct = encrypt ty bs
+         in decrypt ty val ct == Just bs
     it "matches Bool" $ property $ \b ->
       matches (V TBool b) TBool
     it "matches Pair" $ property $ \a b ->
-      matches (V (TPair TInt TString) (a,b)) (TPair TInt TString)
+      matches (V (TPair TInt TString) (a, b)) (TPair TInt TString)
     it "matches List" $ property $ \xs ->
       matches (V (TList TInt) xs) (TList TInt)

--- a/haskell/typecrypt.cabal
+++ b/haskell/typecrypt.cabal
@@ -9,7 +9,8 @@ library
   build-depends:
       base >=4.7 && <5,
       bytestring >=0.10,
-      cryptonite >=0.27
+      cryptonite >=0.27,
+      memory >=0.18
   default-language: Haskell2010
 
 test-suite spec
@@ -21,6 +22,7 @@ test-suite spec
       typecrypt,
       bytestring,
       cryptonite >=0.27,
+      memory >=0.18,
       QuickCheck,
       hspec >=2.7
   default-language: Haskell2010


### PR DESCRIPTION
## Summary
- add QuickCheck `Arbitrary ByteString` instance for tests
- add properties checking roundtrip encryption for pair and list types
- add nested pair/list test case
- fix nonce creation in `Types.hs`
- include `memory` dependency in cabal file

## Testing
- `cabal test`

------
https://chatgpt.com/codex/tasks/task_e_68629c39619883288dfba7d45cea5328