### PR TITLE
Add Racket CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,14 @@ jobs:
         with:
           version: 0.11.0
       - run: zig version
+
+  racket:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Bogdanp/setup-racket@v1
+        with:
+          version: '8.17'
+      - run: |
+          cd racket
+          racket main.rkt

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -5,3 +5,4 @@ set -e
 ( cd haskell && cabal test )
 ( cd rust && cargo test )
 ( cd zig && zig build )
+( cd racket && racket main.rkt )


### PR DESCRIPTION
## Summary
- include a Racket job in the main CI workflow
- update helper script to run the Racket build

## Testing
- `./run_all_tests.sh` *(fails: `cabal` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629efec7e883289d6475ae4a43c657