### PR TITLE
Fix Racket CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: Bogdanp/setup-racket@v1
+      - uses: Bogdanp/setup-racket@v1.14
         with:
           version: '8.17'
       - run: |

--- a/.github/workflows/racket.yml
+++ b/.github/workflows/racket.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Racket
-        uses: Bogdanp/setup-racket@v1
+        uses: Bogdanp/setup-racket@v1.14
         with:
           version: '8.17'
       - name: Run Racket script


### PR DESCRIPTION
## Summary
- use a specific tag for `setup-racket` action in `racket.yml`
- update the main CI workflow to use the same version

## Testing
- `./run_all_tests.sh` *(fails: cabal: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629fe12fac8328b6d290506253c229