### PR TITLE
Add basic tests for all implementations

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -36,19 +36,19 @@ cargo test
 ```
 
 ### Zig
-The Zig example currently just builds an executable. Run:
+Run the Zig unit tests via the build system:
 
 ```bash
 cd zig
-zig build
+zig build test
 ```
 
 ### Racket
-Generate the assembly output by running:
+Execute the rackunit tests:
 
 ```bash
 cd racket
-racket main.rkt
+raco test test.rkt
 ```
 
 ## Multi-Language Workflow

--- a/racket/main.rkt
+++ b/racket/main.rkt
@@ -5,6 +5,8 @@
 (struct Type (name) #:transparent)
 (struct Value (type val) #:transparent)
 
+(provide Type Value TInt matches emit-add)
+
 (define TInt (Type 'int))
 
 ;; Check if a Value matches a Type

--- a/racket/test.rkt
+++ b/racket/test.rkt
@@ -1,0 +1,11 @@
+#lang racket
+(require rackunit "main.rkt")
+
+(module+ test
+  (check-true (matches (Value TInt 1) TInt))
+  (check-false (matches (Value TInt 1) (Type 'str)))
+  (check-exn exn:fail? (lambda () (emit-add (Value TInt 1)
+                                             (Value (Type 'str) "oops"))))
+  (when (file-exists? "output.s") (delete-file "output.s"))
+  (emit-add (Value TInt 1) (Value TInt 2))
+  (check-true (file-exists? "output.s")))

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -4,5 +4,5 @@ set -e
 
 ( cd haskell && cabal test )
 ( cd rust && cargo test )
-( cd zig && zig build )
-( cd racket && racket main.rkt )
+( cd zig && zig build test )
+( cd racket && raco test test.rkt )

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,10 +25,8 @@ pub fn matches(value: &Value, ty: &Type) -> bool {
         (Value::Int(_), Type::Int) => true,
         (Value::Str(_), Type::Str) => true,
         (Value::Bool(_), Type::Bool) => true,
-        (Value::Pair(a, b), Type::Pair(ta, tb)) =>
-            matches(a, ta) && matches(b, tb),
-        (Value::List(vals), Type::List(t)) =>
-            vals.iter().all(|v| matches(v, t)),
+        (Value::Pair(a, b), Type::Pair(ta, tb)) => matches(a, ta) && matches(b, tb),
+        (Value::List(vals), Type::List(t)) => vals.iter().all(|v| matches(v, t)),
         _ => false,
     }
 }

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -12,4 +12,10 @@ pub fn build(b: *std.Build) void {
     });
 
     b.installArtifact(exe);
+
+    const tests = b.addTest("src/main.zig");
+    tests.setTarget(target);
+    tests.setBuildMode(mode);
+    const run_tests = b.addRunArtifact(tests);
+    b.step("test", "Run unit tests").dependOn(&run_tests.step);
 }

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -36,3 +36,14 @@ pub fn main() void {
     std.debug.print("int hash: {x}\n", .{int_hash});
     std.debug.print("str hash: {x}\n", .{str_hash});
 }
+
+/// Basic unit tests for typeHash
+
+test "typeHash stable" {
+    const val = typeHash(i32);
+    try std.testing.expectEqual(val, typeHash(i32));
+}
+
+test "typeHash distinct" {
+    try std.testing.expect(typeHash(i32) != typeHash([]const u8));
+}


### PR DESCRIPTION
## Summary
- add rackunit tests for Racket prototype and export internals
- add Zig unit tests and integrate them into build script
- update docs and test runner to run the new suites
- format Rust sources via rustfmt

## Testing
- `./run_all_tests.sh` *(fails: `cabal` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629fc0579c8328a8769f73172a42bb