### PR TITLE
Add tests to CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,18 +15,20 @@ jobs:
       run:
         working-directory: haskell
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Haskell
-      uses: haskell/actions/setup@v2
-      with:
-        ghc-version: '9.2'
-    - name: Cache cabal store
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cabal/store
-          dist-newstyle
-        key: ${{ runner.os }}-cabal-${{ hashFiles('**/cabal.project', '**/*.cabal') }}
-        restore-keys: ${{ runner.os }}-cabal-
-    - name: Build
-      run: cabal build --enable-tests
+      - uses: actions/checkout@v3
+      - name: Set up Haskell
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: '9.2'
+      - name: Cache cabal store
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-cabal-${{ hashFiles('**/cabal.project', '**/*.cabal') }}
+          restore-keys: ${{ runner.os }}-cabal-
+      - name: Build
+        run: cabal build --enable-tests
+      - name: Test
+        run: cabal test --test-show-details=direct

--- a/.github/workflows/racket.yml
+++ b/.github/workflows/racket.yml
@@ -20,5 +20,5 @@ jobs:
         uses: Bogdanp/setup-racket@v1.14
         with:
           version: '8.17'
-      - name: Run Racket script
-        run: racket main.rkt
+      - name: Run tests
+        run: raco test test.rkt


### PR DESCRIPTION
## Summary
- ensure Haskell CI executes the cabal test suite
- update Racket workflow to run its rackunit tests

## Testing
- `cargo test --quiet`
- `zig build test` *(fails: `zig` not found)*
- `raco test test.rkt` *(fails: `raco` not found)*
- `cabal test` *(fails: `cabal` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a9566a70832886b8dd3943d32f61