### PR TITLE
Add nonce uniqueness property to Haskell tests

### DIFF
--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -61,3 +61,9 @@ main = hspec $ do
       let t = TList TInt
           ct = encrypt t bs
        in decrypt t (V t xs) ct == Just bs
+    it "multiple encryptions use different nonces" $
+      property $ \(bs :: ByteString) -> ioProperty $ do
+        let ty = TInt
+            ct1 = encrypt ty bs
+            ct2 = encrypt ty bs
+        pure (ct1 /= ct2)


### PR DESCRIPTION
## Summary
- check that consecutive encryptions yield different ciphertexts

## Testing
- `./run_all_tests.sh` *(fails: `cabal` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862aa16bc88832882907198011a1da3