### PR TITLE
Add index page for GitHub Pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# TypeCrypt 🔐
+
+Welcome to the TypeCrypt project homepage. TypeCrypt is an experiment in **type-driven encryption**, where access control is enforced by types themselves.
+
+## About
+
+This repository contains coordinated implementations across multiple languages:
+
+- **Haskell** – the theory branch
+- **Rust** – the production branch
+- **Zig** – the experimental branch
+- **Racket** – the assembly branch
+
+See the [README](../README.md) for details on building and testing each implementation.
+
+## Repository Links
+
+- [Source on GitHub](https://github.com/seanwevans/TypeCrypt)
+- [Project Roadmap](../ROADMAP.md)
+


### PR DESCRIPTION
## Summary
- add a `docs/index.md` page so GitHub Pages can build `seanwevans.github.io/TypeCrypt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862acb8111c8328926bcf78f0736889