### PR TITLE
Fix Haskell test suite

### DIFF
--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -69,12 +69,9 @@ main = hspec $ do
         let t = TList TInt
         ct <- encrypt t bs
         pure $ decrypt t (V t xs) ct == Just bs
-      let t = TList TInt
-          ct = encrypt t bs
-       in decrypt t (V t xs) ct == Just bs
     it "multiple encryptions use different nonces" $
       property $ \(bs :: ByteString) -> ioProperty $ do
         let ty = TInt
-            ct1 = encrypt ty bs
-            ct2 = encrypt ty bs
+        ct1 <- encrypt ty bs
+        ct2 <- encrypt ty bs
         pure (ct1 /= ct2)


### PR DESCRIPTION
## Summary
- fix the `roundtrips for List` property
- fix the property checking nonce uniqueness

## Testing
- `cargo test` (rust)
- `zig build test` *(fails: `zig` not found)*
- `raco test test.rkt` *(fails: `raco` not found)*
- `./run_all_tests.sh` *(fails: `cabal` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ac5da63483288d991b31da9dd32e