### PR TITLE
Improve Rust key derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In TypeCrypt, types are not just annotations — they are *structural constraint
 
 This flips conventional cryptography on its head: instead of using values to unlock data, you must *satisfy a type* to access it.
 
-Each implementation derives a symmetric key directly from a `Type` using the `keyFromType` function.  In both Haskell and Rust this mapping currently chooses a fixed 32‑byte key per constructor and encrypts data with ChaCha20‑Poly1305.  The `encrypt` function prepends a random nonce to the ciphertext, while `decrypt` verifies that a provided `Value` matches the expected `Type` before attempting to decrypt.  Although the key derivation is simplistic and **not** secure for real use, it clearly demonstrates the idea of tying access to type satisfaction.
+Each implementation derives a symmetric key directly from a `Type` using the `keyFromType` function.  Haskell still maps each constructor to a fixed 32‑byte key, while the Rust branch now hashes a canonical byte encoding of the type with SHA‑256.  Data is encrypted with ChaCha20‑Poly1305 and the `encrypt` function prepends a random nonce to the ciphertext.  `decrypt` verifies that a provided `Value` matches the expected `Type` before attempting to decrypt.  Although the key derivation is still simplistic and **not** ready for real use, it demonstrates the idea of tying access to type satisfaction.
 
 ## Development Workflow
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,7 +17,7 @@ The project is organized into four interoperating implementations:
   - Generates simple x86_64 assembly snippets for low-level exploration.
   - Serves as a sandbox for examining minimal representations.
 
-Internally each branch shares the same core idea: derive a symmetric key from a `Type` and authenticate that a runtime `Value` matches that type before revealing the plaintext.  The Haskell and Rust implementations both use fixed 32-byte keys per constructor and encrypt data with ChaCha20-Poly1305.  Although this mapping is purely demonstrative, it shows how type satisfaction gates decryption.
+Internally each branch shares the same core idea: derive a symmetric key from a `Type` and authenticate that a runtime `Value` matches that type before revealing the plaintext.  Haskell still uses fixed 32-byte keys per constructor, while Rust now hashes a canonical byte encoding of the type with SHA-256.  Both branches encrypt data with ChaCha20-Poly1305.  Although this mapping is purely demonstrative, it shows how type satisfaction gates decryption.
 
 Changes generally flow from Haskell to Rust to Zig. Haskell establishes the formal semantics; Rust implements them in a production setting; Zig prototypes new concepts that may feed back upstream.
 


### PR DESCRIPTION
## Summary
- enhance Rust key derivation by hashing a canonical byte encoding of `Type`
- document the new approach in `README.md` and `docs/overview.md`
- add tests for deterministic and distinct key generation

## Testing
- `cargo fmt`
- `cargo test --quiet`
- `./run_all_tests.sh` *(fails: `cabal` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ad952e448328bdbce8cff48b7259