### PR TITLE
Improve Racket assembly emitter

### DIFF
--- a/racket/README.md
+++ b/racket/README.md
@@ -2,4 +2,4 @@
 
 This directory contains a small Racket prototype that demonstrates emitting x86_64 assembly.
 
-Running `racket main.rkt` will generate an `output.s` file with assembly for a simple addition function.
+Running `racket main.rkt` will generate an `output.s` file with assembly for a simple addition function.  The module also exposes `emit-sub` for subtraction and a generic `emit-binop` helper that can be extended with new operations.

--- a/racket/test.rkt
+++ b/racket/test.rkt
@@ -8,4 +8,7 @@
                                              (Value (Type 'str) "oops"))))
   (when (file-exists? "output.s") (delete-file "output.s"))
   (emit-add (Value TInt 1) (Value TInt 2))
+  (check-true (file-exists? "output.s"))
+  (delete-file "output.s")
+  (emit-sub (Value TInt 5) (Value TInt 2))
   (check-true (file-exists? "output.s")))


### PR DESCRIPTION
## Summary
- generalize Racket assembly generation with `emit-binop`
- support subtraction via `emit-sub`
- test new functionality
- document additions in Racket README

## Testing
- `raco test racket/test.rkt`
- `./run_all_tests.sh` *(fails: `cabal` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ad905f708328adf71b6b864f4aba