### PR TITLE
Improve Haskell tests

### DIFF
--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -75,3 +75,12 @@ main = hspec $ do
         ct1 <- encrypt ty bs
         ct2 <- encrypt ty bs
         pure (ct1 /= ct2)
+    it "fails to decrypt with mismatched Value" $
+      property $ \(bs :: ByteString) (s :: String) -> ioProperty $ do
+        let ty = TInt
+        ct <- encrypt ty bs
+        pure $ decrypt ty (V TString s) ct == Nothing
+    it "fails to decrypt with wrong Type" $
+      property $ \(n :: Int) bs -> ioProperty $ do
+        ct <- encrypt TInt bs
+        pure $ decrypt TString (V TInt n) ct == Nothing


### PR DESCRIPTION
## Summary
- add QuickCheck properties that verify decryption fails when the value or type does not match

## Testing
- `cargo test`
- `zig build test` *(fails: `zig` not found)*
- `raco test test.rkt` *(fails: `raco` not found)*
- `cabal test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862ad99dfb48328a670ad2282e82fab