### PR TITLE
Add QuickCheck test for truncated ciphertext

### DIFF
--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -84,3 +84,9 @@ main = hspec $ do
       property $ \(n :: Int) bs -> ioProperty $ do
         ct <- encrypt TInt bs
         pure $ decrypt TString (V TInt n) ct == Nothing
+
+    it "fails to decrypt when ciphertext is truncated" $
+      property $ \(n :: Int) (bs :: ByteString) -> ioProperty $ do
+        ct <- encrypt TInt bs
+        let truncated = B.take (B.length ct - 1) ct
+        pure $ decrypt TInt (V TInt n) truncated == Nothing


### PR DESCRIPTION
## Summary
- verify decryption fails on truncated ciphertext in the Haskell test suite

## Testing
- `./run_all_tests.sh` *(fails: `cabal` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b07323a48328acb3b48e7760de9f