### PR TITLE
Fix ciphertext length check in decrypt_with_value

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -87,7 +87,7 @@ pub fn decrypt_with_value(ty: &Type, value: &Value, ciphertext: &[u8]) -> Option
     if !matches(value, ty) {
         return None;
     }
-    if ciphertext.len() < 12 {
+    if ciphertext.len() < 12 + aead::CHACHA20_POLY1305.tag_len() {
         return None;
     }
     let key = key_from_type(ty);


### PR DESCRIPTION
## Summary
- enforce minimum ciphertext length before decrypting

## Testing
- `./run_all_tests.sh` *(fails: `zig` and `racket` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862b06f0c088328b87d1acff7131674