### PR TITLE
Fix build script handling

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -20,10 +20,11 @@ This document summarizes the basic coding style used in this repository and how 
 ## Running Tests
 
 ### Haskell
-Run the QuickCheck suite via cabal:
+Run the QuickCheck suite via cabal. Make sure the package index is up to date:
 
 ```bash
 cd haskell
+cabal update
 cabal test
 ```
 

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -2,7 +2,15 @@
 # Run all TypeCrypt test suites
 set -e
 
-( cd haskell && cabal test )
+( cd haskell && cabal update && cabal test )
 ( cd rust && cargo test )
-( cd zig && zig build test )
-( cd racket && raco test test.rkt )
+if command -v zig >/dev/null 2>&1; then
+  ( cd zig && zig build test )
+else
+  echo "Skipping Zig tests: zig compiler not installed"
+fi
+if command -v raco >/dev/null 2>&1; then
+  ( cd racket && raco test test.rkt )
+else
+  echo "Skipping Racket tests: raco not installed"
+fi


### PR DESCRIPTION
## Summary
- update `run_all_tests.sh` to run `cabal update` and skip missing toolchains
- document running `cabal update` before tests

## Testing
- `cargo test`
- `raco test test.rkt`
- `./run_all_tests.sh` *(fails: building Haskell dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862b061f0a8832889247798cbce83a2