### PR TITLE
Update run_all_tests.sh with tool checks

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -2,13 +2,24 @@
 # Run all TypeCrypt test suites
 set -e
 
-( cd haskell && cabal update && cabal test )
-( cd rust && cargo test )
+if command -v cabal >/dev/null 2>&1; then
+  ( cd haskell && cabal update && cabal test )
+else
+  echo "Skipping Haskell tests: cabal not installed"
+fi
+
+if command -v cargo >/dev/null 2>&1; then
+  ( cd rust && cargo test )
+else
+  echo "Skipping Rust tests: cargo not installed"
+fi
+
 if command -v zig >/dev/null 2>&1; then
   ( cd zig && zig build test )
 else
   echo "Skipping Zig tests: zig compiler not installed"
 fi
+
 if command -v raco >/dev/null 2>&1; then
   ( cd racket && raco test test.rkt )
 else


### PR DESCRIPTION
## Summary
- guard Haskell tests behind `cabal` availability
- guard Rust tests behind `cargo` availability
- keep existing checks for Zig and Racket

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862ced942648328ac05a0c509f5fa5a