### PR TITLE
Add cargo fmt check in Rust CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,5 +20,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Format
+        run: cargo fmt -- --check
       - name: Test
         run: cargo test --verbose


### PR DESCRIPTION
## Summary
- run `cargo fmt -- --check` in rust CI before tests

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686318e809d883288d8e5de987331444