### PR TITLE
Add truncated ciphertext test

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -179,4 +179,13 @@ mod tests {
         let k2 = derive_key_bytes(&Type::Str);
         assert_ne!(k1, k2);
     }
+
+    #[test]
+    fn decrypt_fails_on_truncated_ciphertext() {
+        let ty = Type::Int;
+        let value = Value::Int(5);
+        let mut ct = encrypt(&ty, b"data");
+        ct.pop();
+        assert!(decrypt_with_value(&ty, &value, &ct).is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- add a regression test for truncated ciphertexts in the Rust crate

## Testing
- `./run_all_tests.sh`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686318e5da6883288173817d7b83e85f