### PR TITLE
Add CI workflow with JSONL logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Haskell
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: '9.2'
+      - name: Cache cabal store
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cabal/store
+            haskell/dist-newstyle
+          key: ${{ runner.os }}-cabal-${{ hashFiles('haskell/cabal.project', 'haskell/**/*.cabal') }}
+          restore-keys: ${{ runner.os }}-cabal-
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: 0.11.0
+      - name: Setup Racket
+        uses: Bogdanp/setup-racket@v1.14
+        with:
+          version: '8.17'
+      - name: Run all tests
+        run: ./run_all_tests.sh
+      - name: Record JSONL log
+        if: always()
+        run: |
+          status="${{ job.status }}"
+          timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "{\"agent\": \"ci\", \"task\": \"run_all_tests\", \"status\": \"$status\", \"timestamp\": \"$timestamp\"}" > test-results.jsonl
+      - name: Upload log artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ci-logs
+          path: test-results.jsonl

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,3 +55,7 @@ raco test test.rkt
 ## Multi-Language Workflow
 
 This project coordinates changes across the Haskell, Rust, Zig and Racket implementations. See `AGENTS.md` in the repository root for details on how updates should flow between these directories.
+
+## Continuous Integration
+
+The workflow in `.github/workflows/ci.yml` installs the Haskell, Rust, Zig and Racket toolchains and then runs `./run_all_tests.sh`. After the tests finish it writes a JSONL log entry with the pass/fail result and uploads that file as a build artifact. The log format matches the example in `AGENTS.md`.


### PR DESCRIPTION
## Summary
- introduce `ci.yml` workflow that installs all toolchains
- run `./run_all_tests.sh` and always emit a JSONL log
- document the CI workflow in `development.md`

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d5affad188328b59de4c38bebac5e