### PR TITLE
Update gitignore for Zig and Racket outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ rust/target/
 *.o
 *.beam
 *.swp
+zig/zig-cache/
+zig/zig-out/
+racket/output.s


### PR DESCRIPTION
## Summary
- ignore Zig build folders
- ignore Racket output

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688bfe66a89c8328bbf4a180e754bb87