### PR TITLE
Add cross-language encryption roundtrip test

### DIFF
--- a/rust/src/bin/crypt_tool.rs
+++ b/rust/src/bin/crypt_tool.rs
@@ -1,0 +1,48 @@
+use std::env;
+use typecrypt::{decrypt_with_value, encrypt, Type, Value};
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn unhex(s: &str) -> Vec<u8> {
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+        .collect()
+}
+
+const PLAINTEXT: &[u8] = b"cross-test";
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("usage: encrypt|decrypt <hex>");
+        std::process::exit(1);
+    }
+    match args[1].as_str() {
+        "encrypt" => {
+            let ct = encrypt(&Type::Int, PLAINTEXT);
+            println!("{}", hex(&ct));
+        }
+        "decrypt" => {
+            if args.len() != 3 {
+                eprintln!("decrypt requires hex ciphertext");
+                std::process::exit(1);
+            }
+            let ct = unhex(&args[2]);
+            let val = Value::Int(0);
+            match decrypt_with_value(&Type::Int, &val, &ct) {
+                Some(pt) => println!("{}", String::from_utf8_lossy(&pt)),
+                None => {
+                    println!("FAIL");
+                    std::process::exit(1);
+                }
+            }
+        }
+        _ => {
+            eprintln!("usage: encrypt|decrypt <hex>");
+            std::process::exit(1);
+        }
+    }
+}

--- a/tests/cross_lang_key_derivation.sh
+++ b/tests/cross_lang_key_derivation.sh
@@ -24,6 +24,19 @@ fi
 ( cd zig && zig build )
 
 # Run helpers
+
+# Cross-language encryption roundtrip
+PLAINTEXT="cross-test"
+HS_CT=$(cd haskell && cabal exec runghc -- -isrc ../tests/crypt_hs.hs encrypt)
+RS_CT=$(cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool encrypt)
+HS_DEC_RS=$(cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool decrypt "$HS_CT")
+RS_DEC_HS=$(cd haskell && cabal exec runghc -- -isrc ../tests/crypt_hs.hs decrypt "$RS_CT")
+if [ "$HS_DEC_RS" != "$PLAINTEXT" ] || [ "$RS_DEC_HS" != "$PLAINTEXT" ]; then
+  echo "Cross-language encryption mismatch" >&2
+  exit 1
+fi
+
+# Existing key derivation helpers
 HS_OUTPUT=$(cd haskell && cabal exec runghc -- -isrc ../tests/dump_hs.hs)
 RS_OUTPUT=$(cargo run --quiet --manifest-path rust/Cargo.toml --bin dump_keys)
 ZIG_OUTPUT=$(zig run tests/dump_zig.zig)

--- a/tests/crypt_hs.hs
+++ b/tests/crypt_hs.hs
@@ -1,0 +1,34 @@
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as C
+import Numeric (readHex, showHex)
+import System.Environment (getArgs)
+import Types
+
+hex :: B.ByteString -> String
+hex bs = concatMap twoHex (B.unpack bs)
+  where
+    twoHex n = let h = showHex n "" in if length h == 1 then '0' : h else h
+
+unhex :: String -> B.ByteString
+unhex [] = B.empty
+unhex (a : b : rest) =
+  let [(n, _)] = readHex [a, b]
+   in B.cons n (unhex rest)
+unhex _ = error "invalid hex"
+
+plaintext :: B.ByteString
+plaintext = C.pack "cross-test"
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    ["encrypt"] -> do
+      ct <- encrypt TInt plaintext
+      putStrLn (hex ct)
+    ["decrypt", hexCt] -> do
+      let ct = unhex hexCt
+      case decrypt TInt (V TInt (0 :: Int)) ct of
+        Just pt -> C.putStrLn pt
+        Nothing -> putStrLn "FAIL"
+    _ -> putStrLn "usage: encrypt|decrypt [hex]"


### PR DESCRIPTION
## Summary
- implement encryption helper binaries for Haskell and Rust
- extend cross-language test to verify ciphertexts interchange

## Testing
- `./run_all_tests.sh` *(fails: Skipping cross-language test: cabal not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688bfe66ee348328bf169038019c4683