### PR TITLE
feat: derive keys using HKDF

### DIFF
--- a/haskell/src/Types.hs
+++ b/haskell/src/Types.hs
@@ -5,12 +5,14 @@ module Types where
 
 import qualified Crypto.Cipher.ChaChaPoly1305 as C
 import Crypto.Error (CryptoFailable (..), throwCryptoError)
-import Crypto.Hash (Digest, SHA256, hash)
+import Crypto.Hash (SHA256)
+import Crypto.KDF.HKDF (PRK, expand, extract)
 import Crypto.MAC.Poly1305 (authTag)
 import Crypto.Random (getRandomBytes)
 import Data.ByteArray (constEq, convert)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as B8
 import Data.Word (Word8)
 
 -- | Type algebra using GADTs.
@@ -65,7 +67,13 @@ canonicalBytes t = B.pack (go t)
 
 -- | Internal: derive a symmetric key from a 'Type'.
 keyFromType :: Type a -> B.ByteString
-keyFromType ty = convert (hash (canonicalBytes ty) :: Digest SHA256)
+keyFromType ty =
+  let ikm = canonicalBytes ty
+      salt = B8.pack "TypeCryptHKDFSalt"
+      info = B8.pack "TypeCryptHKDFInfo"
+      prk :: PRK SHA256
+      prk = extract salt ikm
+   in expand prk info 32
 
 encrypt :: Type a -> ByteString -> IO ByteString
 encrypt ty plaintext = do

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -32,7 +32,7 @@ pub fn matches(value: &Value, ty: &Type) -> bool {
 }
 
 use ring::aead;
-use ring::digest;
+use ring::hkdf;
 use ring::rand::{SecureRandom, SystemRandom};
 
 fn canonical_bytes(ty: &Type, out: &mut Vec<u8>) {
@@ -55,9 +55,13 @@ fn canonical_bytes(ty: &Type, out: &mut Vec<u8>) {
 fn derive_key_bytes(ty: &Type) -> [u8; 32] {
     let mut bytes = Vec::new();
     canonical_bytes(ty, &mut bytes);
-    let hash = digest::digest(&digest::SHA256, &bytes);
+    let salt = hkdf::Salt::new(hkdf::HKDF_SHA256, b"TypeCryptHKDFSalt");
+    let prk = salt.extract(&bytes);
+    let okm = prk
+        .expand(&[b"TypeCryptHKDFInfo"], hkdf::HKDF_SHA256)
+        .expect("hkdf expand");
     let mut out = [0u8; 32];
-    out.copy_from_slice(hash.as_ref());
+    okm.fill(&mut out).expect("hkdf fill");
     out
 }
 

--- a/tests/dump_hs.hs
+++ b/tests/dump_hs.hs
@@ -1,21 +1,25 @@
-import Types
 import qualified Data.ByteString as B
 import Numeric (showHex)
+import Types
 
 hex :: B.ByteString -> String
 hex bs = concatMap twoHex (B.unpack bs)
-  where twoHex n = let h = showHex n "" in if length h == 1 then '0':h else h
+  where
+    twoHex n = let h = showHex n "" in if length h == 1 then '0' : h else h
 
 printInfo :: (String, Type a) -> IO ()
 printInfo (name, ty) = do
   let bytes = canonicalBytes ty
+      -- keyFromType now derives keys via HKDF-SHA256 with fixed salt/info
       key = keyFromType ty
   putStrLn $ "{\"type\":\"" ++ name ++ "\",\"bytes\":" ++ show (B.unpack bytes) ++ ",\"key\":\"" ++ hex key ++ "\"}"
 
 main :: IO ()
-main = mapM_ printInfo
-  [ ("int", TInt)
-  , ("str", TString)
-  , ("pair", TPair TInt TBool)
-  , ("list", TList TInt)
-  ]
+main =
+  mapM_
+    printInfo
+    [ ("int", TInt),
+      ("str", TString),
+      ("pair", TPair TInt TBool),
+      ("list", TList TInt)
+    ]


### PR DESCRIPTION
## Summary
- replace SHA-256 key derivation with HKDF-SHA256 using constant salt/info in Haskell, Rust, and Zig
- update key dump utilities for all languages to emit HKDF-derived keys

## Testing
- `./run_all_tests.sh` *(fails: zig test Debug native: error: the following command terminated unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_6893aa8558e883288792678d96ba826d