### PR TITLE
Add Zig CLI to cross-language tests

### DIFF
--- a/tests/cross_lang_key_derivation.sh
+++ b/tests/cross_lang_key_derivation.sh
@@ -29,9 +29,16 @@ fi
 PLAINTEXT="cross-test"
 HS_CT=$(cd haskell && cabal exec runghc -- -isrc ../tests/crypt_hs.hs encrypt)
 RS_CT=$(cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool encrypt)
+ZIG_CT=$(zig run tests/crypt_zig.zig -- encrypt)
 HS_DEC_RS=$(cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool decrypt "$HS_CT")
 RS_DEC_HS=$(cd haskell && cabal exec runghc -- -isrc ../tests/crypt_hs.hs decrypt "$RS_CT")
-if [ "$HS_DEC_RS" != "$PLAINTEXT" ] || [ "$RS_DEC_HS" != "$PLAINTEXT" ]; then
+HS_DEC_ZG=$(cd haskell && cabal exec runghc -- -isrc ../tests/crypt_hs.hs decrypt "$ZIG_CT")
+RS_DEC_ZG=$(cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool decrypt "$ZIG_CT")
+ZIG_DEC_HS=$(zig run tests/crypt_zig.zig -- decrypt "$HS_CT")
+ZIG_DEC_RS=$(zig run tests/crypt_zig.zig -- decrypt "$RS_CT")
+if [ "$HS_DEC_RS" != "$PLAINTEXT" ] || [ "$RS_DEC_HS" != "$PLAINTEXT" ] || \
+   [ "$HS_DEC_ZG" != "$PLAINTEXT" ] || [ "$RS_DEC_ZG" != "$PLAINTEXT" ] || \
+   [ "$ZIG_DEC_HS" != "$PLAINTEXT" ] || [ "$ZIG_DEC_RS" != "$PLAINTEXT" ]; then
   echo "Cross-language encryption mismatch" >&2
   exit 1
 fi

--- a/tests/crypt_zig.zig
+++ b/tests/crypt_zig.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+
+fn deriveKey() [32]u8 {
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    hasher.update(&[_]u8{0});
+    var out: [32]u8 = undefined;
+    hasher.final(out[0..]);
+    return out;
+}
+
+fn encrypt(plaintext: []const u8) ![]u8 {
+    var key = deriveKey();
+    var nonce: [12]u8 = undefined;
+    std.crypto.random.bytes(&nonce);
+    const tag_len = std.crypto.aead.chacha_poly.ChaCha20Poly1305.tag_length;
+    var ct = try std.heap.page_allocator.alloc(u8, plaintext.len);
+    defer std.heap.page_allocator.free(ct);
+    var tag: [tag_len]u8 = undefined;
+    std.crypto.aead.chacha_poly.ChaCha20Poly1305.encrypt(ct, &tag, plaintext, &[_]u8{}, nonce, key);
+    var out = try std.heap.page_allocator.alloc(u8, nonce.len + ct.len + tag_len);
+    std.mem.copy(u8, out[0..nonce.len], &nonce);
+    std.mem.copy(u8, out[nonce.len .. nonce.len + ct.len], ct);
+    std.mem.copy(u8, out[nonce.len + ct.len ..], &tag);
+    return out;
+}
+
+fn decrypt(ciphertext: []const u8) !?[]u8 {
+    const tag_len = std.crypto.aead.chacha_poly.ChaCha20Poly1305.tag_length;
+    if (ciphertext.len < 12 + tag_len) return null;
+    var key = deriveKey();
+    var nonce: [12]u8 = undefined;
+    std.mem.copy(u8, &nonce, ciphertext[0..12]);
+    const ct_len = ciphertext.len - 12 - tag_len;
+    const ct = ciphertext[12 .. 12 + ct_len];
+    var tag: [tag_len]u8 = undefined;
+    std.mem.copy(u8, &tag, ciphertext[12 + ct_len ..]);
+    var pt = try std.heap.page_allocator.alloc(u8, ct_len);
+    std.crypto.aead.chacha_poly.ChaCha20Poly1305.decrypt(pt, ct, tag, &[_]u8{}, nonce, key) catch {
+        std.heap.page_allocator.free(pt);
+        return null;
+    };
+    return pt;
+}
+
+fn hex(allocator: std.mem.Allocator, buf: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}", .{std.fmt.fmtSliceHexLower(buf)});
+}
+
+fn unhex(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
+    const n = s.len / 2;
+    var out = try allocator.alloc(u8, n);
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        out[i] = try std.fmt.parseInt(u8, s[i * 2 .. i * 2 + 2], 16);
+    }
+    return out;
+}
+
+pub fn main() !void {
+    var gpa = std.heap.page_allocator;
+    const args = try std.process.argsAlloc(gpa);
+    defer std.process.argsFree(gpa, args);
+    if (args.len < 2) {
+        try std.io.getStdErr().writer().print("usage: encrypt|decrypt <hex>\n", .{});
+        std.process.exit(1);
+    }
+    const cmd = args[1];
+    const plaintext = "cross-test";
+    if (std.mem.eql(u8, cmd, "encrypt")) {
+        const ct = try encrypt(plaintext);
+        defer gpa.free(ct);
+        const hex_ct = try hex(gpa, ct);
+        defer gpa.free(hex_ct);
+        try std.io.getStdOut().writer().print("{s}\n", .{hex_ct});
+    } else if (std.mem.eql(u8, cmd, "decrypt")) {
+        if (args.len != 3) {
+            try std.io.getStdErr().writer().print("decrypt requires hex ciphertext\n", .{});
+            std.process.exit(1);
+        }
+        const ct_bytes = try unhex(gpa, args[2]);
+        defer gpa.free(ct_bytes);
+        const pt_opt = try decrypt(ct_bytes);
+        if (pt_opt) |pt| {
+            defer gpa.free(pt);
+            try std.io.getStdOut().writer().print("{s}\n", .{pt});
+        } else {
+            try std.io.getStdOut().writer().print("FAIL\n", .{});
+            std.process.exit(1);
+        }
+    } else {
+        try std.io.getStdErr().writer().print("usage: encrypt|decrypt <hex>\n", .{});
+        std.process.exit(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add Zig-based encrypt/decrypt helper mirroring other language tools
- extend cross-language key derivation script to cover Zig ciphertexts

## Testing
- `zig run tests/crypt_zig.zig -- encrypt`
- `bash tests/cross_lang_key_derivation.sh` *(fails: cabal not installed)*
- `./run_all_tests.sh` *(fails: zig test segfault)*

------
https://chatgpt.com/codex/tasks/task_e_6893aa8453d88328b64650b25aa0977a