### PR TITLE
Return Result from Rust encrypt/decrypt

### DIFF
--- a/rust/src/bin/crypt_tool.rs
+++ b/rust/src/bin/crypt_tool.rs
@@ -14,7 +14,7 @@ fn unhex(s: &str) -> Vec<u8> {
 
 const PLAINTEXT: &[u8] = b"cross-test";
 
-fn main() {
+fn main() -> Result<(), ring::error::Unspecified> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         eprintln!("usage: encrypt|decrypt <hex>");
@@ -22,7 +22,7 @@ fn main() {
     }
     match args[1].as_str() {
         "encrypt" => {
-            let ct = encrypt(&Type::Int, PLAINTEXT);
+            let ct = encrypt(&Type::Int, PLAINTEXT)?;
             println!("{}", hex(&ct));
         }
         "decrypt" => {
@@ -33,8 +33,8 @@ fn main() {
             let ct = unhex(&args[2]);
             let val = Value::Int(0);
             match decrypt_with_value(&Type::Int, &val, &ct) {
-                Some(pt) => println!("{}", String::from_utf8_lossy(&pt)),
-                None => {
+                Ok(pt) => println!("{}", String::from_utf8_lossy(&pt)),
+                Err(_) => {
                     println!("FAIL");
                     std::process::exit(1);
                 }
@@ -45,4 +45,5 @@ fn main() {
             std::process::exit(1);
         }
     }
+    Ok(())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -61,44 +61,45 @@ fn derive_key_bytes(ty: &Type) -> [u8; 32] {
     out
 }
 
-fn key_from_type(ty: &Type) -> aead::LessSafeKey {
+fn key_from_type(ty: &Type) -> Result<aead::LessSafeKey, ring::error::Unspecified> {
     let bytes = derive_key_bytes(ty);
-    let unbound = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &bytes).expect("invalid key");
-    aead::LessSafeKey::new(unbound)
+    let unbound = aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &bytes)?;
+    Ok(aead::LessSafeKey::new(unbound))
 }
 
 /// Encrypt the given plaintext using the provided `Type` as the key.
-pub fn encrypt(ty: &Type, plaintext: &[u8]) -> Vec<u8> {
-    let key = key_from_type(ty);
+pub fn encrypt(ty: &Type, plaintext: &[u8]) -> Result<Vec<u8>, ring::error::Unspecified> {
+    let key = key_from_type(ty)?;
     let rng = SystemRandom::new();
     let mut nonce_bytes = [0u8; 12];
-    rng.fill(&mut nonce_bytes).expect("random failure");
+    rng.fill(&mut nonce_bytes)?;
     let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
     let mut in_out = plaintext.to_vec();
-    key.seal_in_place_append_tag(nonce, aead::Aad::empty(), &mut in_out)
-        .expect("encryption failure");
+    key.seal_in_place_append_tag(nonce, aead::Aad::empty(), &mut in_out)?;
     let mut out = nonce_bytes.to_vec();
     out.extend_from_slice(&in_out);
-    out
+    Ok(out)
 }
 
 /// Decrypt the ciphertext if the value matches the expected type.
-pub fn decrypt_with_value(ty: &Type, value: &Value, ciphertext: &[u8]) -> Option<Vec<u8>> {
+pub fn decrypt_with_value(
+    ty: &Type,
+    value: &Value,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, ring::error::Unspecified> {
     if !matches(value, ty) {
-        return None;
+        return Err(ring::error::Unspecified);
     }
     if ciphertext.len() < 12 + aead::CHACHA20_POLY1305.tag_len() {
-        return None;
+        return Err(ring::error::Unspecified);
     }
-    let key = key_from_type(ty);
+    let key = key_from_type(ty)?;
     let mut nonce_bytes = [0u8; 12];
     nonce_bytes.copy_from_slice(&ciphertext[..12]);
     let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
     let mut in_out = ciphertext[12..].to_vec();
-    let result = key
-        .open_in_place(nonce, aead::Aad::empty(), &mut in_out)
-        .ok()?;
-    Some(result.to_vec())
+    let result = key.open_in_place(nonce, aead::Aad::empty(), &mut in_out)?;
+    Ok(result.to_vec())
 }
 
 #[cfg(test)]
@@ -106,20 +107,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn encrypt_decrypt_roundtrip() {
+    fn encrypt_decrypt_roundtrip() -> Result<(), ring::error::Unspecified> {
         let ty = Type::Int;
         let value = Value::Int(42);
-        let ct = encrypt(&ty, b"hello");
-        let pt = decrypt_with_value(&ty, &value, &ct).expect("decrypt");
+        let ct = encrypt(&ty, b"hello")?;
+        let pt = decrypt_with_value(&ty, &value, &ct)?;
         assert_eq!(pt, b"hello");
+        Ok(())
     }
 
     #[test]
-    fn decrypt_rejects_wrong_value() {
+    fn decrypt_rejects_wrong_value() -> Result<(), ring::error::Unspecified> {
         let ty = Type::Int;
         let wrong = Value::Str("oops".into());
-        let ct = encrypt(&ty, b"secret");
-        assert!(decrypt_with_value(&ty, &wrong, &ct).is_none());
+        let ct = encrypt(&ty, b"secret")?;
+        assert!(decrypt_with_value(&ty, &wrong, &ct).is_err());
+        Ok(())
     }
 
     #[test]
@@ -155,14 +158,15 @@ mod tests {
     }
 
     #[test]
-    fn multiple_encryptions_use_different_nonces() {
+    fn multiple_encryptions_use_different_nonces() -> Result<(), ring::error::Unspecified> {
         let ty = Type::Int;
         let value = Value::Int(7);
-        let ct1 = encrypt(&ty, b"hello");
-        let ct2 = encrypt(&ty, b"hello");
+        let ct1 = encrypt(&ty, b"hello")?;
+        let ct2 = encrypt(&ty, b"hello")?;
         assert_ne!(ct1, ct2);
-        assert_eq!(decrypt_with_value(&ty, &value, &ct1).unwrap(), b"hello");
-        assert_eq!(decrypt_with_value(&ty, &value, &ct2).unwrap(), b"hello");
+        assert_eq!(decrypt_with_value(&ty, &value, &ct1)?, b"hello");
+        assert_eq!(decrypt_with_value(&ty, &value, &ct2)?, b"hello");
+        Ok(())
     }
 
     #[test]
@@ -181,11 +185,12 @@ mod tests {
     }
 
     #[test]
-    fn decrypt_fails_on_truncated_ciphertext() {
+    fn decrypt_fails_on_truncated_ciphertext() -> Result<(), ring::error::Unspecified> {
         let ty = Type::Int;
         let value = Value::Int(5);
-        let mut ct = encrypt(&ty, b"data");
+        let mut ct = encrypt(&ty, b"data")?;
         ct.pop();
-        assert!(decrypt_with_value(&ty, &value, &ct).is_none());
+        assert!(decrypt_with_value(&ty, &value, &ct).is_err());
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- return `Result` from `encrypt` and `decrypt_with_value`
- update tests and CLI to handle propagation

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893aa80e400832887af897643e478eb