### PR TITLE
rust: expose canonical and key derivation helpers

### DIFF
--- a/rust/src/bin/dump_keys.rs
+++ b/rust/src/bin/dump_keys.rs
@@ -1,31 +1,4 @@
-use ring::digest;
-use typecrypt::Type;
-
-fn canonical_bytes(ty: &Type, out: &mut Vec<u8>) {
-    match ty {
-        Type::Int => out.push(0),
-        Type::Str => out.push(1),
-        Type::Bool => out.push(2),
-        Type::Pair(a, b) => {
-            out.push(3);
-            canonical_bytes(a, out);
-            canonical_bytes(b, out);
-        }
-        Type::List(t) => {
-            out.push(4);
-            canonical_bytes(t, out);
-        }
-    }
-}
-
-fn derive_key_bytes(ty: &Type) -> [u8; 32] {
-    let mut bytes = Vec::new();
-    canonical_bytes(ty, &mut bytes);
-    let hash = digest::digest(&digest::SHA256, &bytes);
-    let mut out = [0u8; 32];
-    out.copy_from_slice(hash.as_ref());
-    out
-}
+use typecrypt::{canonical_bytes, derive_key_bytes, Type};
 
 fn hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect()

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -35,7 +35,7 @@ use ring::aead;
 use ring::digest;
 use ring::rand::{SecureRandom, SystemRandom};
 
-fn canonical_bytes(ty: &Type, out: &mut Vec<u8>) {
+pub fn canonical_bytes(ty: &Type, out: &mut Vec<u8>) {
     match ty {
         Type::Int => out.push(0),
         Type::Str => out.push(1),
@@ -52,7 +52,7 @@ fn canonical_bytes(ty: &Type, out: &mut Vec<u8>) {
     }
 }
 
-fn derive_key_bytes(ty: &Type) -> [u8; 32] {
+pub fn derive_key_bytes(ty: &Type) -> [u8; 32] {
     let mut bytes = Vec::new();
     canonical_bytes(ty, &mut bytes);
     let hash = digest::digest(&digest::SHA256, &bytes);


### PR DESCRIPTION
## Summary
- make canonical_bytes and derive_key_bytes public in the Rust library
- reuse canonical_bytes and derive_key_bytes in dump_keys binary

## Testing
- `cargo test`
- `./run_all_tests.sh` *(Haskell, Zig, Racket tests skipped: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6893aa8002908328bbe4fed0c2c2028d