### PR TITLE
Handle ChaChaPoly1305 nonce errors safely

### DIFF
--- a/haskell/src/Types.hs
+++ b/haskell/src/Types.hs
@@ -4,7 +4,7 @@
 module Types where
 
 import qualified Crypto.Cipher.ChaChaPoly1305 as C
-import Crypto.Error (CryptoFailable (..), throwCryptoError)
+import Crypto.Error (CryptoFailable (..))
 import Crypto.Hash (Digest, SHA256, hash)
 import Crypto.MAC.Poly1305 (authTag)
 import Crypto.Random (getRandomBytes)
@@ -67,18 +67,19 @@ canonicalBytes t = B.pack (go t)
 keyFromType :: Type a -> B.ByteString
 keyFromType ty = convert (hash (canonicalBytes ty) :: Digest SHA256)
 
-encrypt :: Type a -> ByteString -> IO ByteString
+encrypt :: Type a -> ByteString -> IO (Maybe ByteString)
 encrypt ty plaintext = do
   nonceBytes <- getRandomBytes 12
   let key = keyFromType ty
-      nonce = case C.nonce12 nonceBytes of
-        CryptoFailed _ -> error "invalid nonce"
-        CryptoPassed n -> n
-      st1 = throwCryptoError $ C.initialize key nonce
-      st2 = C.finalizeAAD st1
-      (out, st3) = C.encrypt plaintext st2
-      tag = C.finalize st3
-  pure $ nonceBytes `B.append` out `B.append` convert tag
+  pure $ case C.nonce12 nonceBytes of
+    CryptoFailed _ -> Nothing
+    CryptoPassed nonce -> case C.initialize key nonce of
+      CryptoFailed _ -> Nothing
+      CryptoPassed st1 ->
+        let st2 = C.finalizeAAD st1
+            (out, st3) = C.encrypt plaintext st2
+            tag = C.finalize st3
+         in Just $ nonceBytes `B.append` out `B.append` convert tag
 
 -- | Decrypt if the value matches the expected type and authentication tag checks.
 decrypt :: Type a -> Value -> ByteString -> Maybe ByteString
@@ -89,13 +90,15 @@ decrypt ty val input
       let (nonceBytes, rest) = B.splitAt 12 input
           (ct, tagBytes) = B.splitAt (B.length rest - 16) rest
           key = keyFromType ty
-          nonce = case C.nonce12 nonceBytes of
-            CryptoFailed _ -> error "invalid nonce"
-            CryptoPassed n -> n
-          st1 = throwCryptoError $ C.initialize key nonce
-          st2 = C.finalizeAAD st1
-          (pt, st3) = C.decrypt ct st2
-          tag = C.finalize st3
-       in case authTag tagBytes of
+       in case C.nonce12 nonceBytes of
             CryptoFailed _ -> Nothing
-            CryptoPassed t -> if constEq t tag then Just pt else Nothing
+            CryptoPassed nonce -> case C.initialize key nonce of
+              CryptoFailed _ -> Nothing
+              CryptoPassed st1 ->
+                let st2 = C.finalizeAAD st1
+                    (pt, st3) = C.decrypt ct st2
+                    tag = C.finalize st3
+                 in case authTag tagBytes of
+                      CryptoFailed _ -> Nothing
+                      CryptoPassed t ->
+                        if constEq t tag then Just pt else Nothing


### PR DESCRIPTION
## Summary
- Use `Maybe` to propagate nonce/initialization failures in Haskell ChaChaPoly1305 `encrypt` and `decrypt`
- Adjust tests to expect `Maybe` ciphertexts and handle encryption failures

## Testing
- `./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893aa7f3c288328b20c55b3b848544e