### PR TITLE
Derive Clone and equality traits for core Rust types

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate will implement the hardened TypeCrypt engine.
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Type {
     Int,
     Str,
@@ -11,7 +11,7 @@ pub enum Type {
     List(Box<Type>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Value {
     Int(i32),
     Str(String),


### PR DESCRIPTION
## Summary
- Derive `Clone`, `PartialEq`, and `Eq` for `Type` and `Value` enums

## Testing
- `cargo test`
- `./run_all_tests.sh` *(Haskell, Zig, Racket tests skipped: cabal, zig, raco not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689d27a914bc8328b5a86503f2b3d42c