### PR TITLE
Expose library key helpers

### DIFF
--- a/rust/src/bin/dump_keys.rs
+++ b/rust/src/bin/dump_keys.rs
@@ -1,35 +1,4 @@
-use ring::hkdf;
-use typecrypt::Type;
-
-fn canonical_bytes(ty: &Type, out: &mut Vec<u8>) {
-    match ty {
-        Type::Int => out.push(0),
-        Type::Str => out.push(1),
-        Type::Bool => out.push(2),
-        Type::Pair(a, b) => {
-            out.push(3);
-            canonical_bytes(a, out);
-            canonical_bytes(b, out);
-        }
-        Type::List(t) => {
-            out.push(4);
-            canonical_bytes(t, out);
-        }
-    }
-}
-
-fn derive_key_bytes(ty: &Type) -> [u8; 32] {
-    let mut bytes = Vec::new();
-    canonical_bytes(ty, &mut bytes);
-    let salt = hkdf::Salt::new(hkdf::HKDF_SHA256, b"TypeCryptHKDFSalt");
-    let prk = salt.extract(&bytes);
-    let okm = prk
-        .expand(&[b"TypeCryptHKDFInfo"], hkdf::HKDF_SHA256)
-        .expect("hkdf expand");
-    let mut out = [0u8; 32];
-    okm.fill(&mut out).expect("hkdf fill");
-    out
-}
+use typecrypt::{canonical_bytes, derive_key_bytes, Type};
 
 fn hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect()


### PR DESCRIPTION
## Summary
- expose canonical_bytes and derive_key_bytes from the library and reuse them in dump_keys
- remove duplicate key derivation code from dump_keys

## Testing
- `cargo test`
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689d27aa1a7883288de9ead3c0471c76