### PR TITLE
haskell: refine decrypt errors

### DIFF
--- a/tests/crypt_hs.hs
+++ b/tests/crypt_hs.hs
@@ -29,6 +29,6 @@ main = do
     ["decrypt", hexCt] -> do
       let ct = unhex hexCt
       case decrypt TInt (V TInt (0 :: Int)) ct of
-        Just pt -> C.putStrLn pt
-        Nothing -> putStrLn "FAIL"
+        Right pt -> C.putStrLn pt
+        Left _ -> putStrLn "FAIL"
     _ -> putStrLn "usage: encrypt|decrypt [hex]"


### PR DESCRIPTION
## Summary
- add `DecryptError` and switch `decrypt` to `Either`
- adjust tests and scripts to pattern match on `Right`/`Left`

## Testing
- `cabal test`
- `./run_all_tests.sh` *(fails: Skipping Zig tests: zig compiler not installed; Skipping Racket tests: raco not installed; Skipping cross-language test: zig not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689d27a7cf048328bd455dfeb470a910