### PR TITLE
Add type flags for cross-language crypto tooling

### DIFF
--- a/rust/src/bin/crypt_tool.rs
+++ b/rust/src/bin/crypt_tool.rs
@@ -14,25 +14,52 @@ fn unhex(s: &str) -> Vec<u8> {
 
 const PLAINTEXT: &[u8] = b"cross-test";
 
+fn parse_type(name: &str) -> Option<Type> {
+    match name {
+        "int" => Some(Type::Int),
+        "str" => Some(Type::Str),
+        "pair" => Some(Type::Pair(Box::new(Type::Int), Box::new(Type::Bool))),
+        _ => None,
+    }
+}
+
+fn default_value(ty: &Type) -> Value {
+    match ty {
+        Type::Int => Value::Int(0),
+        Type::Str => Value::Str(String::new()),
+        Type::Bool => Value::Bool(false),
+        Type::Pair(a, b) => Value::Pair(Box::new(default_value(a)), Box::new(default_value(b))),
+        Type::List(_) => Value::List(vec![]),
+    }
+}
+
+fn usage() -> ! {
+    eprintln!("usage: encrypt|decrypt <type> [hex]");
+    std::process::exit(1);
+}
+
 fn main() -> Result<(), ring::error::Unspecified> {
     let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("usage: encrypt|decrypt <hex>");
-        std::process::exit(1);
+    if args.len() < 3 {
+        usage();
     }
     match args[1].as_str() {
         "encrypt" => {
-            let ct = encrypt(&Type::Int, PLAINTEXT)?;
+            if args.len() != 3 {
+                usage();
+            }
+            let ty = parse_type(&args[2]).unwrap_or_else(|| usage());
+            let ct = encrypt(&ty, PLAINTEXT)?;
             println!("{}", hex(&ct));
         }
         "decrypt" => {
-            if args.len() != 3 {
-                eprintln!("decrypt requires hex ciphertext");
-                std::process::exit(1);
+            if args.len() != 4 {
+                usage();
             }
-            let ct = unhex(&args[2]);
-            let val = Value::Int(0);
-            match decrypt_with_value(&Type::Int, &val, &ct) {
+            let ty = parse_type(&args[2]).unwrap_or_else(|| usage());
+            let ct = unhex(&args[3]);
+            let val = default_value(&ty);
+            match decrypt_with_value(&ty, &val, &ct) {
                 Ok(pt) => println!("{}", String::from_utf8_lossy(&pt)),
                 Err(_) => {
                     println!("FAIL");
@@ -40,10 +67,7 @@ fn main() -> Result<(), ring::error::Unspecified> {
                 }
             }
         }
-        _ => {
-            eprintln!("usage: encrypt|decrypt <hex>");
-            std::process::exit(1);
-        }
+        _ => usage(),
     }
     Ok(())
 }

--- a/tests/crypt_zig.zig
+++ b/tests/crypt_zig.zig
@@ -1,42 +1,86 @@
 const std = @import("std");
 
-fn deriveKey() [32]u8 {
-    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    hasher.update(&[_]u8{0});
+pub const Tag = enum { Int, Str, Bool, Pair, List };
+
+pub const Type = union(Tag) {
+    Int: void,
+    Str: void,
+    Bool: void,
+    Pair: struct { a: *const Type, b: *const Type },
+    List: *const Type,
+};
+
+fn canonicalBytesImpl(ty: Type, list: *std.ArrayList(u8)) !void {
+    switch (ty) {
+        .Int => try list.append(0),
+        .Str => try list.append(1),
+        .Bool => try list.append(2),
+        .Pair => |p| {
+            try list.append(3);
+            try canonicalBytesImpl(p.a.*, list);
+            try canonicalBytesImpl(p.b.*, list);
+        },
+        .List => |elem| {
+            try list.append(4);
+            try canonicalBytesImpl(elem.*, list);
+        },
+    }
+}
+
+fn canonicalBytes(allocator: std.mem.Allocator, ty: Type) ![]u8 {
+    var list = std.ArrayList(u8).init(allocator);
+    try canonicalBytesImpl(ty, &list);
+    return list.toOwnedSlice();
+}
+
+fn deriveKey(allocator: std.mem.Allocator, ty: Type) ![32]u8 {
+    const bytes = try canonicalBytes(allocator, ty);
+    defer allocator.free(bytes);
+    const salt = "TypeCryptHKDFSalt";
+    const info = "TypeCryptHKDFInfo";
+    const prk = std.crypto.hkdf.HkdfSha256.extract(salt, bytes);
     var out: [32]u8 = undefined;
-    hasher.final(out[0..]);
+    std.crypto.hkdf.HkdfSha256.expand(out[0..], info, prk);
     return out;
 }
 
-fn encrypt(plaintext: []const u8) ![]u8 {
-    var key = deriveKey();
+fn encrypt(
+    allocator: std.mem.Allocator,
+    ty: Type,
+    plaintext: []const u8,
+) ![]u8 {
+    const key = try deriveKey(allocator, ty);
     var nonce: [12]u8 = undefined;
     std.crypto.random.bytes(&nonce);
     const tag_len = std.crypto.aead.chacha_poly.ChaCha20Poly1305.tag_length;
-    var ct = try std.heap.page_allocator.alloc(u8, plaintext.len);
-    defer std.heap.page_allocator.free(ct);
+    var ct = try allocator.alloc(u8, plaintext.len);
+    defer allocator.free(ct);
     var tag: [tag_len]u8 = undefined;
     std.crypto.aead.chacha_poly.ChaCha20Poly1305.encrypt(ct, &tag, plaintext, &[_]u8{}, nonce, key);
-    var out = try std.heap.page_allocator.alloc(u8, nonce.len + ct.len + tag_len);
+    var out = try allocator.alloc(u8, nonce.len + ct.len + tag_len);
     std.mem.copy(u8, out[0..nonce.len], &nonce);
     std.mem.copy(u8, out[nonce.len .. nonce.len + ct.len], ct);
     std.mem.copy(u8, out[nonce.len + ct.len ..], &tag);
     return out;
 }
 
-fn decrypt(ciphertext: []const u8) !?[]u8 {
+fn decrypt(
+    allocator: std.mem.Allocator,
+    ty: Type,
+    ciphertext: []const u8,
+) !?[]u8 {
     const tag_len = std.crypto.aead.chacha_poly.ChaCha20Poly1305.tag_length;
     if (ciphertext.len < 12 + tag_len) return null;
-    var key = deriveKey();
+    const key = try deriveKey(allocator, ty);
     var nonce: [12]u8 = undefined;
     std.mem.copy(u8, &nonce, ciphertext[0..12]);
     const ct_len = ciphertext.len - 12 - tag_len;
     const ct = ciphertext[12 .. 12 + ct_len];
     var tag: [tag_len]u8 = undefined;
     std.mem.copy(u8, &tag, ciphertext[12 + ct_len ..]);
-    var pt = try std.heap.page_allocator.alloc(u8, ct_len);
+    var pt = try allocator.alloc(u8, ct_len);
     std.crypto.aead.chacha_poly.ChaCha20Poly1305.decrypt(pt, ct, tag, &[_]u8{}, nonce, key) catch {
-        std.heap.page_allocator.free(pt);
+        allocator.free(pt);
         return null;
     };
     return pt;
@@ -56,30 +100,57 @@ fn unhex(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
     return out;
 }
 
+const ty_int = Type{ .Int = {} };
+const ty_str = Type{ .Str = {} };
+const ty_bool = Type{ .Bool = {} };
+const ty_pair = Type{ .Pair = .{ .a = &ty_int, .b = &ty_bool } };
+
+fn parseType(name: []const u8) !Type {
+    if (std.mem.eql(u8, name, "int")) return ty_int;
+    if (std.mem.eql(u8, name, "str")) return ty_str;
+    if (std.mem.eql(u8, name, "pair")) return ty_pair;
+    return error.UnknownType;
+}
+
+fn usage() !void {
+    try std.io.getStdErr().writer().print(
+        "usage: encrypt|decrypt <type> [hex]\n",
+        .{},
+    );
+}
+
 pub fn main() !void {
     var gpa = std.heap.page_allocator;
     const args = try std.process.argsAlloc(gpa);
     defer std.process.argsFree(gpa, args);
-    if (args.len < 2) {
-        try std.io.getStdErr().writer().print("usage: encrypt|decrypt <hex>\n", .{});
+    if (args.len < 3) {
+        try usage();
         std.process.exit(1);
     }
     const cmd = args[1];
+    const ty = parseType(args[2]) catch {
+        try std.io.getStdErr().writer().print("unknown type\n", .{});
+        std.process.exit(1);
+    };
     const plaintext = "cross-test";
     if (std.mem.eql(u8, cmd, "encrypt")) {
-        const ct = try encrypt(plaintext);
+        if (args.len != 3) {
+            try usage();
+            std.process.exit(1);
+        }
+        const ct = try encrypt(gpa, ty, plaintext);
         defer gpa.free(ct);
         const hex_ct = try hex(gpa, ct);
         defer gpa.free(hex_ct);
         try std.io.getStdOut().writer().print("{s}\n", .{hex_ct});
     } else if (std.mem.eql(u8, cmd, "decrypt")) {
-        if (args.len != 3) {
-            try std.io.getStdErr().writer().print("decrypt requires hex ciphertext\n", .{});
+        if (args.len != 4) {
+            try usage();
             std.process.exit(1);
         }
-        const ct_bytes = try unhex(gpa, args[2]);
+        const ct_bytes = try unhex(gpa, args[3]);
         defer gpa.free(ct_bytes);
-        const pt_opt = try decrypt(ct_bytes);
+        const pt_opt = try decrypt(gpa, ty, ct_bytes);
         if (pt_opt) |pt| {
             defer gpa.free(pt);
             try std.io.getStdOut().writer().print("{s}\n", .{pt});
@@ -88,7 +159,8 @@ pub fn main() !void {
             std.process.exit(1);
         }
     } else {
-        try std.io.getStdErr().writer().print("usage: encrypt|decrypt <hex>\n", .{});
+        try usage();
         std.process.exit(1);
     }
 }
+


### PR DESCRIPTION
## Summary
- Allow crypt_hs, crypt_tool, and crypt_zig to encrypt/decrypt based on a type flag (int, str, pair)
- Test cross-language roundtrip for multiple types in cross_lang_key_derivation.sh
- Include new variants in key-derivation consistency checks

## Testing
- `./run_all_tests.sh` *(fails: Skipping Zig tests: zig compiler not installed; Skipping Racket tests: raco not installed; Skipping cross-language test: cabal not installed)*
- `cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool encrypt int`
- `cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool decrypt int 8c953fd5c8ed2fd981fa16516202fa415ead01a7039988d3cf29c35f61979052352c5220a367`
- `cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool encrypt str`
- `cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool decrypt str bbccfa2ec0d8644ab78b9ebe31781942d2f9a671d4674342fbd76aac9fb5865a873eadb64d4a`
- `cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool encrypt pair`
- `cargo run --quiet --manifest-path rust/Cargo.toml --bin crypt_tool decrypt pair ecea54fd9c5bd5dd889ca2a71a28b9111ddfa68aa539d70e04bd19b17264d2c0e702210e964b`


------
https://chatgpt.com/codex/tasks/task_e_68a269b80fe883289bb02c882a500381