### PR TITLE
Use HKDF-SHA256 in Zig test harness

### DIFF
--- a/tests/dump_zig.zig
+++ b/tests/dump_zig.zig
@@ -38,9 +38,9 @@ fn deriveKey(allocator: std.mem.Allocator, ty: Type) ![32]u8 {
     defer allocator.free(bytes);
     const salt = "TypeCryptHKDFSalt";
     const info = "TypeCryptHKDFInfo";
-    const prk = std.crypto.hkdf.HkdfSha256.extract(salt, bytes);
+    const prk = std.crypto.kdf.hkdf.HkdfSha256.extract(salt, bytes);
     var out: [32]u8 = undefined;
-    std.crypto.hkdf.HkdfSha256.expand(out[0..], info, prk);
+    std.crypto.kdf.hkdf.HkdfSha256.expand(out[0..], info, prk);
     return out;
 }
 


### PR DESCRIPTION
## Summary
- derive Zig test keys with HKDF-SHA256 using canonical type bytes
- update dump utility to the same HKDF path

## Testing
- `./run_all_tests.sh`
- `tests/cross_lang_key_derivation.sh` *(fails: Skipping cross-language test: cabal not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a269af204c83288313a4719aa38bec