### PR TITLE
Document predicate/functional-encryption research direction and fix Rust CLI test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ In TypeCrypt, types are not just annotations — they are *structural constraint
 
 This flips conventional cryptography on its head: instead of using values to unlock data, you must *satisfy a type* to access it.
 
-Each implementation derives a symmetric key directly from a `Type` using the `keyFromType` function.  Both the Haskell and Rust branches now hash a canonical byte encoding of the type with SHA‑256.  Data is encrypted with ChaCha20‑Poly1305 and the `encrypt` function prepends a random nonce to the ciphertext.  `decrypt` verifies that a provided `Value` matches the expected `Type` before attempting to decrypt.  Although the key derivation is still simplistic and **not** ready for real use, it demonstrates the idea of tying access to type satisfaction.
+Each implementation derives a symmetric key directly from a `Type` using the `keyFromType` function.  Both the Haskell and Rust branches now hash a canonical byte encoding of the type with SHA‑256.  Data is encrypted with ChaCha20‑Poly1305 and the `encrypt` function prepends a random nonce to the ciphertext.  `decrypt` verifies that a provided `Value` matches the expected `Type` before attempting to decrypt.
+
+This prototype is **not** predicate encryption and is **not** ready for real use: the current security boundary is still conventional AEAD plus application-side type checking. The research-grade direction is to bind decryption to predicate or type satisfaction cryptographically, as in predicate encryption and functional encryption, so that decryption succeeds iff the encoded predicate holds. See [docs/research.md](docs/research.md) for the distinction and research roadmap.
 
 ## Development Workflow
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,6 +65,21 @@ as work progresses and corresponding GitHub issues are resolved.
 
 ---
 
+## 🧪 Research-Grade Cryptographic Binding
+
+> _Purpose_: Move beyond a demonstrative matcher-gated AEAD wrapper toward predicate/type satisfaction enforced by cryptographic construction.
+
+**Goals:**
+- [ ] Map TypeCrypt `Type` constructors to an explicit predicate class
+- [ ] Specify key generation, encryption, and decryption algorithms for predicate/type-bound access
+- [ ] Evaluate predicate-encryption and functional-encryption constructions as possible backends
+- [ ] Document the security model, leakage profile, and collusion-resistance assumptions
+- [ ] Keep the existing matcher as a semantics oracle while avoiding security claims based on application-side `if` checks
+
+See [docs/research.md](docs/research.md) for the detailed research framing.
+
+---
+
 ## 🧮 Long-Term Goals
 
 - [ ] Transpile Haskell IR to:

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,5 @@ See the [README](../README.md) for details on building and testing each implemen
 
 - [Source on GitHub](https://github.com/seanwevans/TypeCrypt)
 - [Project Roadmap](../ROADMAP.md)
+- [Research Direction](research.md)
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,7 +17,9 @@ The project is organized into four interoperating implementations:
   - Generates simple x86_64 assembly snippets for low-level exploration.
   - Serves as a sandbox for examining minimal representations.
 
-Internally each branch shares the same core idea: derive a symmetric key from a `Type` and authenticate that a runtime `Value` matches that type before revealing the plaintext.  Both the Haskell and Rust implementations hash a canonical byte encoding of the type with SHA-256.  Data is encrypted with ChaCha20-Poly1305.  Although this mapping is purely demonstrative, it shows how type satisfaction gates decryption.
+Internally each branch shares the same core idea: derive a symmetric key from a `Type` and authenticate that a runtime `Value` matches that type before revealing the plaintext.  Both the Haskell and Rust implementations hash a canonical byte encoding of the type with SHA-256.  Data is encrypted with ChaCha20-Poly1305.  This mapping is purely demonstrative: it is a type-aware AEAD wrapper, not a predicate-encryption construction.
+
+The long-term research target is cryptographic enforcement of predicate/type satisfaction. In that model, ciphertexts and keys are generated so that decryption succeeds only when an encoded predicate holds, following the predicate-encryption and functional-encryption line of work. The current matcher remains useful as an executable semantics reference, but future security claims should be made only for a backend that embeds satisfaction in the cryptographic construction itself. See [Research Direction](research.md) for details.
 
 Changes generally flow from Haskell to Rust to Zig. Haskell establishes the formal semantics; Rust implements them in a production setting; Zig prototypes new concepts that may feed back upstream.
 

--- a/docs/research.md
+++ b/docs/research.md
@@ -1,0 +1,61 @@
+# Research Direction: Predicate and Functional Encryption
+
+TypeCrypt's current implementations are a **demonstration layer**: they derive a
+symmetric key from a canonical `Type` encoding, verify that a supplied runtime
+`Value` matches that type, and only then attempt AEAD decryption. That is useful
+for exploring interfaces and cross-language canonicalization, but the predicate
+check is still performed by program logic before decryption.
+
+The research-grade version of TypeCrypt is closer to **predicate encryption** and
+**functional encryption**. In those systems, ciphertexts and secret keys are
+constructed so that the cryptographic operation itself enforces an access
+relation. A ciphertext can be associated with a predicate `P`, a secret key can be
+associated with an attribute or value `v`, and decryption succeeds only when
+`P(v)` holds. No caller-visible `if matches(value, type)` gate is trusted for
+security; the satisfaction relation is embedded in the pairing-, lattice-, or
+other assumption-backed construction.
+
+## Why this matters for TypeCrypt
+
+A type predicate such as “record with field `role = admin` and schema version
+`3`” can be modeled as an access predicate. Binding decryption to that predicate
+cryptographically would make type satisfaction part of the decryption math rather
+than an application-side guard. This is the version of TypeCrypt that could offer
+a genuinely new cryptographic primitive instead of only a type-aware wrapper
+around conventional symmetric encryption.
+
+## Current model versus research target
+
+| Aspect | Current TypeCrypt prototype | Predicate/functional-encryption target |
+| --- | --- | --- |
+| Enforcement point | Runtime matcher checks `Value -> Type -> Bool` before AEAD decrypt | Decryption algorithm succeeds only when the encoded relation is satisfied |
+| Key material | Symmetric key derived from a type descriptor | Master-secret-derived keys tied to attributes, values, functions, or policies |
+| Trust boundary | Application must call the matcher correctly | Security proof covers policy satisfaction under cryptographic assumptions |
+| Main value | Interface design, canonical encodings, cross-language tests | Cryptographic binding of decryption to predicate/type satisfaction |
+
+## Literature anchors
+
+The design space is related to work on predicate encryption, attribute-based
+encryption, and functional encryption, including work by Dan Boneh, Amit Sahai,
+Brent Waters, and successors. Useful starting points include:
+
+- Boneh and Waters, “Conjunctive, Subset, and Range Queries on Encrypted Data.”
+- Katz, Sahai, and Waters, “Predicate Encryption Supporting Disjunctions,
+  Polynomial Equations, and Inner Products.”
+- Boneh, Sahai, and Waters, “Functional Encryption: Definitions and Challenges.”
+
+## Roadmap implications
+
+Future research work should treat the current matcher and type hash as a
+prototype interface, not as the final security mechanism. A credible TypeCrypt
+research branch should:
+
+1. Define a formal mapping from TypeCrypt `Type` constructors to supported
+   predicate classes.
+2. Specify key-generation, encryption, and decryption algorithms where predicate
+   satisfaction is enforced by the construction.
+3. State the security model, leakage profile, and supported collusion resistance.
+4. Keep the existing Haskell `spec/Core.hs` matcher as an executable reference
+   for semantics, while separating it from security claims.
+5. Add test vectors that compare semantic satisfaction in the prototype with
+   cryptographic success/failure in any future predicate-encryption backend.

--- a/rust/src/bin/crypt_tool.rs
+++ b/rust/src/bin/crypt_tool.rs
@@ -1,5 +1,5 @@
 use std::{env, fmt, num::ParseIntError};
-use typecrypt::{decrypt_with_value, encrypt, DecryptError, Type, Value};
+use typecrypt::{decrypt_with_value, encrypt, Type, Value};
 
 fn hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect()
@@ -30,16 +30,18 @@ fn unhex(s: &str) -> Result<Vec<u8>, HexError> {
         .collect()
 }
 
+#[cfg(test)]
 #[derive(Debug)]
 enum CliDecryptError {
     Hex(HexError),
-    Decrypt(DecryptError),
+    Decrypt,
 }
 
+#[cfg(test)]
 fn decrypt_from_hex(ty: &Type, ciphertext_hex: &str) -> Result<Vec<u8>, CliDecryptError> {
     let ct = unhex(ciphertext_hex).map_err(CliDecryptError::Hex)?;
     let val = default_value(ty);
-    decrypt_with_value(ty, &val, ct.as_slice()).map_err(CliDecryptError::Decrypt)
+    decrypt_with_value(ty, &val, ct.as_slice()).map_err(|_| CliDecryptError::Decrypt)
 }
 
 const PLAINTEXT: &[u8] = b"cross-test";
@@ -110,11 +112,7 @@ fn main() -> Result<(), ring::error::Unspecified> {
             let val = default_value(&ty);
             match decrypt_with_value(&ty, &val, &ct) {
                 Ok(pt) => println!("{}", String::from_utf8_lossy(&pt)),
-                Err(CliDecryptError::Hex(err)) => {
-                    eprintln!("invalid ciphertext: {err}");
-                    std::process::exit(1);
-                }
-                Err(CliDecryptError::Decrypt(err)) => {
+                Err(err) => {
                     let _ = err;
                     println!("FAIL");
                     std::process::exit(1);


### PR DESCRIPTION
### Motivation
- Clarify that the current TypeCrypt prototype is a type-aware AEAD wrapper and not a predicate/functional-encryption construction.  
- Surface a research roadmap for moving from application-side matcher checks to cryptographic predicate/type satisfaction.  
- Ensure the Rust CLI test code compiles cleanly with the updated `decrypt_with_value` error type.

### Description
- Add `docs/research.md` explaining the distinction between the prototype and predicate/functional encryption, listing literature anchors and concrete roadmap implications.  
- Update `README.md`, `docs/overview.md`, and `docs/index.md` to link to the new research direction and explicitly state the prototype limitations.  
- Add research goals to `ROADMAP.md` describing the effort to map `Type` constructors to predicate classes and specify predicate-bound keygen/encrypt/decrypt algorithms.  
- Tidy the Rust CLI test helper in `rust/src/bin/crypt_tool.rs` by scoping test-only helpers with `#[cfg(test)]`, removing the unused `DecryptError` import, and simplifying the error match so tests compile and run.

### Testing
- Ran the project test orchestrator with `./run_all_tests.sh`, which completed successfully.  
- The Rust test suite passed: unit tests in `rust/src/lib.rs` and binary tests in `rust/src/bin/crypt_tool.rs` and `rust/tests/` all passed.  
- Haskell, Zig, Racket and the cross-language check were skipped in this environment because their toolchains (`cabal`, `zig`, `raco`) were not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde1e82b448328ba28c79d8db0e33b)